### PR TITLE
Add public key list file management

### DIFF
--- a/public_keys_file.go
+++ b/public_keys_file.go
@@ -1,0 +1,89 @@
+package libtrust
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/libtrust/jwa"
+)
+
+func LoadPublicKeysFile(name, keyDir string) ([]PublicKey, error) {
+	var jwks []json.RawMessage
+	if name != "" {
+		f, err := os.Open(name)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil, ErrKeyFileDoesNotExist
+			}
+			return nil, err
+		}
+		defer f.Close()
+
+		decoder := json.NewDecoder(f)
+
+		err = decoder.Decode(&jwks)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if keyDir != "" {
+		files, err := filepath.Glob(filepath.Join(keyDir, "*.json"))
+		if err != nil {
+			return nil, err
+		}
+		for _, fName := range files {
+			b, err := ioutil.ReadFile(fName)
+			if err != nil {
+				return nil, err
+			}
+
+			jwks = append(jwks, json.RawMessage(b))
+		}
+	}
+
+	pks := make([]PublicKey, len(jwks))
+	for i, jwk := range jwks {
+		key := &jwaPublicKey{}
+		var err error
+		key.key, err = jwa.UnmarshalPublicKeyJSON(jwk)
+		if err != nil {
+			return nil, err
+		}
+		pks[i] = key
+	}
+
+	return pks, nil
+}
+
+func CreatePublicKeysFile(jsonFile string, keys []PublicKey) error {
+	jwks := make([]interface{}, len(keys))
+
+	for i, key := range keys {
+		var jwk interface{}
+		switch kv := key.(type) {
+		case *jwaPublicKey:
+			jwk = kv.key
+		default:
+			return ErrUnsupportKeyType
+		}
+
+		jwks[i] = jwk
+	}
+
+	f, err := os.OpenFile(jsonFile, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	buf, err := json.MarshalIndent(jwks, "", "   ")
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(buf)
+	return err
+
+}

--- a/public_keys_file_test.go
+++ b/public_keys_file_test.go
@@ -1,0 +1,94 @@
+package libtrust
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func createPublicKeysFile(name string, n int) error {
+	keys := make([]PublicKey, n)
+	for i := range keys {
+		pk, err := GenerateJWAKey(EC256)
+		if err != nil {
+			return err
+		}
+		keys[i] = &jwaPublicKey{
+			key: pk.(*jwaKey).key.PublicKey(),
+		}
+	}
+
+	return CreatePublicKeysFile(name, keys)
+}
+
+func createPublicKeysFiles(dir string, n int) error {
+	for i := 0; i < n; i++ {
+		pk, err := GenerateJWAKey(EC256)
+		if err != nil {
+			return err
+		}
+
+		jsonName := fmt.Sprintf("key-%d.json", i)
+
+		f, err := os.OpenFile(path.Join(dir, jsonName), os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		buf, err := json.MarshalIndent(pk.(*jwaKey).key.PublicKey(), "", "   ")
+		if err != nil {
+			return err
+		}
+		_, err = f.Write(buf)
+	}
+
+	return nil
+}
+
+func TestLoadPublicKeysFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "libtrust-unittest-")
+	if err != nil {
+		t.Fatalf("Error creating directory: %s", err)
+	}
+	testfile := "public_keys.json"
+	name := path.Join(dir, testfile)
+	err = createPublicKeysFile(name, 20)
+	if err != nil {
+		t.Fatalf("Error creating public keys file: %s", err)
+	}
+	t.Logf("Creating public keys file: %s", name)
+
+	publicKeys, err := LoadPublicKeysFile(name, "")
+	if err != nil {
+		t.Fatalf("Error loading public keys file: %s", err)
+	}
+
+	if len(publicKeys) != 20 {
+		t.Fatalf("Unexpected number of public keys\n\tExpecting: 20\n\tActual: %d", len(publicKeys))
+	}
+}
+
+func TestPublicKeyDirectory(t *testing.T) {
+	dir, err := ioutil.TempDir("", "libtrust-unittest-")
+	if err != nil {
+		t.Fatalf("Error creating directory: %s", err)
+	}
+	err = createPublicKeysFiles(dir, 25)
+	if err != nil {
+		t.Fatalf("Error creating public key files: %s", err)
+	}
+	t.Logf("Creating public key directory: %s", dir)
+
+	publicKeys, err := LoadPublicKeysFile("", dir)
+	if err != nil {
+		t.Fatalf("Error loading public keys file: %s", err)
+	}
+
+	if len(publicKeys) != 25 {
+		t.Fatalf("Unexpected number of public keys\n\tExpecting: 25\n\tActual: %d", len(publicKeys))
+	}
+}


### PR DESCRIPTION
This should handle loading and creating a file with a list of public keys.  This should be able to handle known hosts and authorized keys scenarios, assuming known hosts will not need more information than the public key.
