### PR TITLE
Refactored cert generation from jwa to libtrust

### DIFF
--- a/certificates.go
+++ b/certificates.go
@@ -1,0 +1,133 @@
+package libtrust
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"github.com/docker/libtrust/jwa"
+	"math/big"
+	"net"
+	"time"
+)
+
+type certTemplateInfo struct {
+	commonName  string
+	domains     []string
+	ipAddresses []net.IP
+	isCA        bool
+	clientAuth  bool
+	serverAuth  bool
+}
+
+func generateCertTemplate(info *certTemplateInfo) *x509.Certificate {
+	// Generate a certificate template which is valid from the past week to
+	// 10 years from now. The usage of the certificate depends on the
+	// specified fields in the given certTempInfo object.
+	var (
+		keyUsage    x509.KeyUsage
+		extKeyUsage []x509.ExtKeyUsage
+	)
+
+	if info.isCA {
+		keyUsage = x509.KeyUsageCertSign
+	}
+
+	if info.clientAuth {
+		extKeyUsage = append(extKeyUsage, x509.ExtKeyUsageClientAuth)
+	}
+
+	if info.serverAuth {
+		extKeyUsage = append(extKeyUsage, x509.ExtKeyUsageServerAuth)
+	}
+
+	return &x509.Certificate{
+		SerialNumber: big.NewInt(0),
+		Subject: pkix.Name{
+			CommonName: info.commonName,
+		},
+		NotBefore:             time.Now().Add(-time.Hour * 24 * 7),
+		NotAfter:              time.Now().Add(time.Hour * 24 * 365 * 10),
+		DNSNames:              info.domains,
+		IPAddresses:           info.ipAddresses,
+		IsCA:                  info.isCA,
+		KeyUsage:              keyUsage,
+		ExtKeyUsage:           extKeyUsage,
+		BasicConstraintsValid: info.isCA,
+	}
+}
+
+func generateCert(pub jwa.PublicKey, priv jwa.PrivateKey, subInfo, issInfo *certTemplateInfo) (cert *x509.Certificate, err error) {
+	pubCertTemplate := generateCertTemplate(subInfo)
+	privCertTemplate := generateCertTemplate(issInfo)
+
+	certDER, err := x509.CreateCertificate(
+		rand.Reader, pubCertTemplate, privCertTemplate,
+		pub.CryptoPublicKey(), priv.CryptoPrivateKey(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create certificate: %s", err)
+	}
+
+	cert, err = x509.ParseCertificate(certDER)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate: %s", err)
+	}
+
+	return
+}
+
+// GenerateSelfSignedServerCert creates a self-signed certificate for the
+// given key which is to be used for TLS servers with the given domains and
+// IP addresses.
+func GenerateSelfSignedServerCert(key jwa.PrivateKey, domains []string, ipAddresses []net.IP) (*x509.Certificate, error) {
+	info := &certTemplateInfo{
+		commonName:  key.KeyID(),
+		domains:     domains,
+		ipAddresses: ipAddresses,
+		serverAuth:  true,
+	}
+
+	return generateCert(key.PublicKey(), key, info, info)
+}
+
+// GenerateSelfSignedClientCert creates a self-signed certificate for the
+// given key which is to be used for TLS clients.
+func GenerateSelfSignedClientCert(key jwa.PrivateKey) (*x509.Certificate, error) {
+	info := &certTemplateInfo{
+		commonName: key.KeyID(),
+		clientAuth: true,
+	}
+
+	return generateCert(key.PublicKey(), key, info, info)
+}
+
+func generateCACert(signer jwa.PrivateKey, trustedKey jwa.PublicKey) (*x509.Certificate, error) {
+	subjectInfo := &certTemplateInfo{
+		commonName: trustedKey.KeyID(),
+		isCA:       true,
+	}
+	issuerInfo := &certTemplateInfo{
+		commonName: signer.KeyID(),
+	}
+
+	return generateCert(trustedKey, signer, subjectInfo, issuerInfo)
+}
+
+// GenerateCACertPool creates a certificate authority pool to be used for a
+// TLS configuration. Any self-signed certificates issued by the specified
+// trusted keys will be verified during a TLS handshake
+func GenerateCACertPool(signer jwa.PrivateKey, trustedKeys []jwa.PublicKey) (*x509.CertPool, error) {
+	certPool := x509.NewCertPool()
+
+	for _, trustedKey := range trustedKeys {
+		cert, err := generateCACert(signer, trustedKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate CA certificate: %s", err)
+		}
+
+		certPool.AddCert(cert)
+	}
+
+	return certPool, nil
+}

--- a/jwa/ec_test.go
+++ b/jwa/ec_test.go
@@ -26,7 +26,6 @@ func generateECTestKeys(t *testing.T) []PrivateKey {
 }
 
 func TestECKeys(t *testing.T) {
-
 	ecKeys := generateECTestKeys(t)
 
 	for _, ecKey := range ecKeys {
@@ -112,29 +111,29 @@ func TestMarshalUnmarshalECKeys(t *testing.T) {
 	}
 }
 
-func TestECGeneratePEMCertKey(t *testing.T) {
+func TestFromCryptoECKeys(t *testing.T) {
 	ecKeys := generateECTestKeys(t)
 
-	keyToSign, err := GenerateECP384PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	for _, ecKey := range ecKeys {
-		keyPEM, err := ecKey.GeneratePEMKey()
+		cryptoPrivateKey := ecKey.CryptoPrivateKey()
+		cryptoPublicKey := ecKey.CryptoPublicKey()
+
+		pubKey, err := FromCryptoPublicKey(cryptoPublicKey)
 		if err != nil {
 			t.Fatal(err)
 		}
-		selfSignedCertPEM, err := ecKey.GeneratePEMCert(ecKey.PublicKey())
+
+		if pubKey.KeyID() != ecKey.KeyID() {
+			t.Fatal("public key key ID mismatch")
+		}
+
+		privKey, err := FromCryptoPrivateKey(cryptoPrivateKey)
 		if err != nil {
 			t.Fatal(err)
 		}
-		signedCertPEM, err := ecKey.GeneratePEMCert(keyToSign.PublicKey())
-		if err != nil {
-			t.Fatal(err)
+
+		if privKey.KeyID() != ecKey.KeyID() {
+			t.Fatal("public key key ID mismatch")
 		}
-		t.Logf("Private Key:\n%s", string(keyPEM))
-		t.Logf("Self-Signed Certificate:\n%s", string(selfSignedCertPEM))
-		t.Logf("Signature of %s Key:\n%s", keyToSign.KeyID(), string(signedCertPEM))
 	}
 }

--- a/jwa/rsa_test.go
+++ b/jwa/rsa_test.go
@@ -18,21 +18,25 @@ func init() {
 }
 
 func generateRSATestKeys() (keys []PrivateKey, err error) {
+	log.Println("Generating RSA 2048-bit Test Key")
 	rsa2048Key, err := GenerateRSA2048PrivateKey()
 	if err != nil {
 		return
 	}
 
+	log.Println("Generating RSA 3072-bit Test Key")
 	rsa3072Key, err := GenerateRSA3072PrivateKey()
 	if err != nil {
 		return
 	}
 
+	log.Println("Generating RSA 4096-bit Test Key")
 	rsa4096Key, err := GenerateRSA4096PrivateKey()
 	if err != nil {
 		return
 	}
 
+	log.Println("Done generating RSA Test Keys!")
 	keys = []PrivateKey{rsa2048Key, rsa3072Key, rsa4096Key}
 
 	return
@@ -127,27 +131,27 @@ func TestMarshalUnmarshalRSAKeys(t *testing.T) {
 	}
 }
 
-func TestRSAGeneratePEMCertKeyPair(t *testing.T) {
-	keyToSign, err := GenerateECP384PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-
+func TestFromCryptoRSAKeys(t *testing.T) {
 	for _, rsaKey := range rsaKeys {
-		keyPEM, err := rsaKey.GeneratePEMKey()
+		cryptoPrivateKey := rsaKey.CryptoPrivateKey()
+		cryptoPublicKey := rsaKey.CryptoPublicKey()
+
+		pubKey, err := FromCryptoPublicKey(cryptoPublicKey)
 		if err != nil {
 			t.Fatal(err)
 		}
-		selfSignedCertPEM, err := rsaKey.GeneratePEMCert(rsaKey.PublicKey())
+
+		if pubKey.KeyID() != rsaKey.KeyID() {
+			t.Fatal("public key key ID mismatch")
+		}
+
+		privKey, err := FromCryptoPrivateKey(cryptoPrivateKey)
 		if err != nil {
 			t.Fatal(err)
 		}
-		signedCertPEM, err := rsaKey.GeneratePEMCert(keyToSign.PublicKey())
-		if err != nil {
-			t.Fatal(err)
+
+		if privKey.KeyID() != rsaKey.KeyID() {
+			t.Fatal("public key key ID mismatch")
 		}
-		t.Logf("Private Key:\n%s", string(keyPEM))
-		t.Logf("Self-Signed Certificate:\n%s", string(selfSignedCertPEM))
-		t.Logf("Signature of %s Key:\n%s", keyToSign.KeyID(), string(signedCertPEM))
 	}
 }


### PR DESCRIPTION
Easier to use function to generate client certificates, server certificates,
and trusted CA certificates.

Added functions to jwa package which allow you to create a JWA public or
private key from a given Public or Private key from the crypto package.

Updated tlsdemo and jwa package tests.
