### PR TITLE
Fix filter hosts invalid cast

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -11,7 +11,7 @@ func FilterByHosts(keys []PublicKey, host string, includeEmpty bool) ([]PublicKe
 	filtered := make([]PublicKey, 0, len(keys))
 
 	for _, pubKey := range keys {
-		hosts, ok := pubKey.GetExtendedField("hosts").([]string)
+		hosts, ok := pubKey.GetExtendedField("hosts").([]interface{})
 
 		if !ok || (ok && len(hosts) == 0) {
 			if includeEmpty {
@@ -21,7 +21,12 @@ func FilterByHosts(keys []PublicKey, host string, includeEmpty bool) ([]PublicKe
 		}
 
 		// Check if any hosts match pattern
-		for _, hostPattern := range hosts {
+		for _, hostVal := range hosts {
+			hostPattern, ok := hostVal.(string)
+			if !ok {
+				continue
+			}
+
 			match, err := filepath.Match(hostPattern, host)
 			if err != nil {
 				return nil, err

--- a/filter_test.go
+++ b/filter_test.go
@@ -33,13 +33,13 @@ func TestFilter(t *testing.T) {
 			break
 		case i%2 == 0:
 			// Should catch keys 2, 4, and 6.
-			key.AddExtendedField("hosts", []string{"*.even.example.com"})
+			key.AddExtendedField("hosts", []interface{}{"*.even.example.com"})
 		case i == 7:
 			// Should catch only the last key, and make it match any hostname.
-			key.AddExtendedField("hosts", []string{"*"})
+			key.AddExtendedField("hosts", []interface{}{"*"})
 		default:
 			// should catch keys 1, 3, 5.
-			key.AddExtendedField("hosts", []string{"*.example.com"})
+			key.AddExtendedField("hosts", []interface{}{"*.example.com"})
 		}
 
 		keys = append(keys, key)


### PR DESCRIPTION
Not sure when this code was reverted back to a direct type assertion against []string.  The unit tests passed with that assertion because the extended type was set to []string directly in the test, however when read from a json file the type is set as []interface{}.
