### PR TITLE
filter hosts should cast hosts value to []string

### DIFF
--- a/filter_test.go
+++ b/filter_test.go
@@ -27,6 +27,8 @@ func TestFilter(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// we use both []interface{} and []string here because jwt uses
+		// []interface{} format, while PEM uses []string
 		switch {
 		case i == 0:
 			// Don't add entries for this key, key 0.
@@ -36,10 +38,10 @@ func TestFilter(t *testing.T) {
 			key.AddExtendedField("hosts", []interface{}{"*.even.example.com"})
 		case i == 7:
 			// Should catch only the last key, and make it match any hostname.
-			key.AddExtendedField("hosts", []interface{}{"*"})
+			key.AddExtendedField("hosts", []string{"*"})
 		default:
 			// should catch keys 1, 3, 5.
-			key.AddExtendedField("hosts", []interface{}{"*.example.com"})
+			key.AddExtendedField("hosts", []string{"*.example.com"})
 		}
 
 		keys = append(keys, key)

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,23 @@
+package libtrust
+
+import (
+	"encoding/pem"
+	"reflect"
+	"testing"
+)
+
+func TestAddPEMHeadersToKey(t *testing.T) {
+	pk := &rsaPublicKey{nil, map[string]interface{}{}}
+	blk := &pem.Block{Headers: map[string]string{"hosts": "localhost,127.0.0.1"}}
+	addPEMHeadersToKey(blk, pk)
+
+	val := pk.GetExtendedField("hosts")
+	hosts, ok := val.([]string)
+	if !ok {
+		t.Fatalf("hosts type(%v), expected []string", reflect.TypeOf(val))
+	}
+	expected := []string{"localhost", "127.0.0.1"}
+	if !reflect.DeepEqual(hosts, expected) {
+		t.Errorf("hosts(%v), expected %v", hosts, expected)
+	}
+}


### PR DESCRIPTION
Instead of casting the hosts value to []interface{} in FilterByHosts (which
doesnt work because user cannot cast interface{} to []interface{}), this patch
casts host value to []string directly.

Without the patch, running `go run gencert.go` will fail with panic
because filtered hosts are empty after casting.

Docker-DCO-1.1-Signed-off-by: Daniel, Dao Quang Minh dqminh89@gmail.com (github: dqminh)
