### PR TITLE
Update permissions to use scope strings

### DIFF
--- a/trustgraph/graph.go
+++ b/trustgraph/graph.go
@@ -8,11 +8,11 @@ type TrustGraph interface {
 	// Verifies that the given public key is allowed to perform
 	// the given action on the given node according to the trust
 	// graph.
-	Verify(libtrust.PublicKey, string, uint16) (bool, error)
+	Verify(libtrust.PublicKey, string, string) (bool, error)
 
 	// GetGrants returns an array of all grant chains which are used to
-	// allow the requested permission.
-	GetGrants(libtrust.PublicKey, string, uint16) ([][]*Grant, error)
+	// allow the requested scope.
+	GetGrants(libtrust.PublicKey, string, string) ([][]*Grant, error)
 }
 
 // Grant represents a transfer of permission from one part of the
@@ -22,8 +22,8 @@ type Grant struct {
 	// Subject is the namespace being granted
 	Subject string
 
-	// Permissions is a bit map of permissions
-	Permission uint16
+	// Scopes is an array of allowed actions.
+	Scopes []string
 
 	// Grantee represents the node being granted
 	// a permission scope.  The grantee can be
@@ -35,16 +35,3 @@ type Grant struct {
 	// this object.
 	statement *Statement
 }
-
-// Permissions
-//  Read node 0x01 (can read node, no sub nodes)
-//  Write node 0x02 (can write to node object, cannot create subnodes)
-//  Read subtree 0x04 (delegates read to each sub node)
-//  Write subtree 0x08 (delegates write to each sub node, included create on the subject)
-//
-// Permission shortcuts
-// ReadItem = 0x01
-// WriteItem = 0x03
-// ReadAccess = 0x07
-// WriteAccess = 0x0F
-// Delegate = 0x0F

--- a/trustgraph/memory_graph_test.go
+++ b/trustgraph/memory_graph_test.go
@@ -16,9 +16,9 @@ func createTestKeysAndGrants(count int) ([]*Grant, []libtrust.PrivateKey) {
 			panic(err)
 		}
 		grant := &Grant{
-			Subject:    fmt.Sprintf("/user-%d", i+1),
-			Permission: 0x0f,
-			Grantee:    pk.KeyID(),
+			Subject: fmt.Sprintf("/user-%d", i+1),
+			Scopes:  []string{"delegate"},
+			Grantee: pk.KeyID(),
 		}
 		keys[i] = pk
 		grants[i] = grant
@@ -26,16 +26,16 @@ func createTestKeysAndGrants(count int) ([]*Grant, []libtrust.PrivateKey) {
 	return grants, keys
 }
 
-func testVerified(t *testing.T, g TrustGraph, k libtrust.PublicKey, keyName, target string, permission uint16) {
-	if ok, err := g.Verify(k, target, permission); err != nil {
+func testVerified(t *testing.T, g TrustGraph, k libtrust.PublicKey, keyName, target string, scope string) {
+	if ok, err := g.Verify(k, target, scope); err != nil {
 		t.Fatalf("Unexpected error during verification: %s", err)
 	} else if !ok {
 		t.Errorf("key failed verification\n\tKey: %s(%s)\n\tNamespace: %s", keyName, k.KeyID(), target)
 	}
 }
 
-func testNotVerified(t *testing.T, g TrustGraph, k libtrust.PublicKey, keyName, target string, permission uint16) {
-	if ok, err := g.Verify(k, target, permission); err != nil {
+func testNotVerified(t *testing.T, g TrustGraph, k libtrust.PublicKey, keyName, target string, scope string) {
+	if ok, err := g.Verify(k, target, scope); err != nil {
 		t.Fatalf("Unexpected error during verification: %s", err)
 	} else if ok {
 		t.Errorf("key should have failed verification\n\tKey: %s(%s)\n\tNamespace: %s", keyName, k.KeyID(), target)
@@ -46,69 +46,69 @@ func TestVerify(t *testing.T) {
 	grants, keys := createTestKeysAndGrants(4)
 	extraGrants := make([]*Grant, 3)
 	extraGrants[0] = &Grant{
-		Subject:    "/user-3",
-		Permission: 0x0f,
-		Grantee:    "/user-2",
+		Subject: "/user-3",
+		Scopes:  []string{"delegate"},
+		Grantee: "/user-2",
 	}
 	extraGrants[1] = &Grant{
-		Subject:    "/user-3/sub-project",
-		Permission: 0x0f,
-		Grantee:    "/user-4",
+		Subject: "/user-3/sub-project",
+		Scopes:  []string{"delegate"},
+		Grantee: "/user-4",
 	}
 	extraGrants[2] = &Grant{
-		Subject:    "/user-4",
-		Permission: 0x07,
-		Grantee:    "/user-1",
+		Subject: "/user-4",
+		Scopes:  []string{"read", "write"},
+		Grantee: "/user-1",
 	}
 	grants = append(grants, extraGrants...)
 
 	g := NewMemoryGraph(grants)
 
-	testVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-1", 0x0f)
-	testVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-1/some-project/sub-value", 0x0f)
-	testVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-4", 0x07)
-	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-2/", 0x0f)
-	testVerified(t, g, keys[2].PublicKey(), "user-key-3", "/user-3/sub-value", 0x0f)
-	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-3/sub-value", 0x0f)
-	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-3", 0x0f)
-	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-3/", 0x0f)
-	testVerified(t, g, keys[3].PublicKey(), "user-key-4", "/user-3/sub-project", 0x0f)
-	testVerified(t, g, keys[3].PublicKey(), "user-key-4", "/user-3/sub-project/app", 0x0f)
-	testVerified(t, g, keys[3].PublicKey(), "user-key-4", "/user-4", 0x0f)
+	testVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-1", "test")
+	testVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-1/some-project/sub-value", "test")
+	testVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-4", "write")
+	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-2/", "test")
+	testVerified(t, g, keys[2].PublicKey(), "user-key-3", "/user-3/sub-value", "test")
+	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-3/sub-value", "test")
+	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-3", "test")
+	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-3/", "test")
+	testVerified(t, g, keys[3].PublicKey(), "user-key-4", "/user-3/sub-project", "test")
+	testVerified(t, g, keys[3].PublicKey(), "user-key-4", "/user-3/sub-project/app", "test")
+	testVerified(t, g, keys[3].PublicKey(), "user-key-4", "/user-4", "test")
 
-	testNotVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-2", 0x0f)
-	testNotVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-3/sub-value", 0x0f)
-	testNotVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-4", 0x0f)
-	testNotVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-1/", 0x0f)
-	testNotVerified(t, g, keys[2].PublicKey(), "user-key-3", "/user-2", 0x0f)
-	testNotVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-4", 0x0f)
-	testNotVerified(t, g, keys[3].PublicKey(), "user-key-4", "/user-3", 0x0f)
+	testNotVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-2", "test")
+	testNotVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-3/sub-value", "test")
+	testNotVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-4", "test")
+	testNotVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-1/", "test")
+	testNotVerified(t, g, keys[2].PublicKey(), "user-key-3", "/user-2", "test")
+	testNotVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-4", "test")
+	testNotVerified(t, g, keys[3].PublicKey(), "user-key-4", "/user-3", "test")
 }
 
 func TestCircularWalk(t *testing.T) {
 	grants, keys := createTestKeysAndGrants(3)
 	user1Grant := &Grant{
-		Subject:    "/user-2",
-		Permission: 0x0f,
-		Grantee:    "/user-1",
+		Subject: "/user-2",
+		Scopes:  []string{"delegate"},
+		Grantee: "/user-1",
 	}
 	user2Grant := &Grant{
-		Subject:    "/user-1",
-		Permission: 0x0f,
-		Grantee:    "/user-2",
+		Subject: "/user-1",
+		Scopes:  []string{"delegate"},
+		Grantee: "/user-2",
 	}
 	grants = append(grants, user1Grant, user2Grant)
 
 	g := NewMemoryGraph(grants)
 
-	testVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-1", 0x0f)
-	testVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-2", 0x0f)
-	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-2", 0x0f)
-	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-1", 0x0f)
-	testVerified(t, g, keys[2].PublicKey(), "user-key-3", "/user-3", 0x0f)
+	testVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-1", "test")
+	testVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-2", "test")
+	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-2", "test")
+	testVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-1", "test")
+	testVerified(t, g, keys[2].PublicKey(), "user-key-3", "/user-3", "test")
 
-	testNotVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-3", 0x0f)
-	testNotVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-3", 0x0f)
+	testNotVerified(t, g, keys[0].PublicKey(), "user-key-1", "/user-3", "test")
+	testNotVerified(t, g, keys[1].PublicKey(), "user-key-2", "/user-3", "test")
 }
 
 func assertGrantSame(t *testing.T, actual, expected *Grant) {
@@ -121,30 +121,30 @@ func TestGetGrants(t *testing.T) {
 	grants, keys := createTestKeysAndGrants(5)
 	extraGrants := make([]*Grant, 4)
 	extraGrants[0] = &Grant{
-		Subject:    "/user-3/friend-project",
-		Permission: 0x0f,
-		Grantee:    "/user-2/friends",
+		Subject: "/user-3/friend-project",
+		Scopes:  []string{"delegate"},
+		Grantee: "/user-2/friends",
 	}
 	extraGrants[1] = &Grant{
-		Subject:    "/user-3/sub-project",
-		Permission: 0x0f,
-		Grantee:    "/user-4",
+		Subject: "/user-3/sub-project",
+		Scopes:  []string{"delegate"},
+		Grantee: "/user-4",
 	}
 	extraGrants[2] = &Grant{
-		Subject:    "/user-2/friends",
-		Permission: 0x0f,
-		Grantee:    "/user-5/fun-project",
+		Subject: "/user-2/friends",
+		Scopes:  []string{"delegate"},
+		Grantee: "/user-5/fun-project",
 	}
 	extraGrants[3] = &Grant{
-		Subject:    "/user-5/fun-project",
-		Permission: 0x0f,
-		Grantee:    "/user-1",
+		Subject: "/user-5/fun-project",
+		Scopes:  []string{"delegate"},
+		Grantee: "/user-1",
 	}
 	grants = append(grants, extraGrants...)
 
 	g := NewMemoryGraph(grants)
 
-	grantChains, err := g.GetGrants(keys[3], "/user-3/sub-project/specific-app", 0x0f)
+	grantChains, err := g.GetGrants(keys[3], "/user-3/sub-project/specific-app", "test")
 	if err != nil {
 		t.Fatalf("Error getting grants: %s", err)
 	}
@@ -157,7 +157,7 @@ func TestGetGrants(t *testing.T) {
 	assertGrantSame(t, grantChains[0][0], grants[3])
 	assertGrantSame(t, grantChains[0][1], extraGrants[1])
 
-	grantChains, err = g.GetGrants(keys[0], "/user-3/friend-project/fun-app", 0x0f)
+	grantChains, err = g.GetGrants(keys[0], "/user-3/friend-project/fun-app", "test")
 	if err != nil {
 		t.Fatalf("Error getting grants: %s", err)
 	}


### PR DESCRIPTION
Update permissions to use scopes as described by #36 

Still need to determine how to represent long-lived revocations which do not overwrite an existing permissions but limit a wider permission.
