### PR TITLE
Add benchmarks for generation and fingerprinting

### DIFF
--- a/key_test.go
+++ b/key_test.go
@@ -16,10 +16,14 @@ func runGenerateBench(b *testing.B, f generateFunc, name string) {
 }
 
 func runFingerprintBench(b *testing.B, f generateFunc, name string) {
+	b.StopTimer()
+	// Don't count this relatively slow generation call.
 	key, err := f()
 	if err != nil {
 		b.Fatalf("Error generating %s: %s", name, err)
 	}
+	b.StartTimer()
+
 	for i := 0; i < b.N; i++ {
 		if key.KeyID() == "" {
 			b.Fatalf("Error generating key ID for %s", name)


### PR DESCRIPTION
Results with `i7-3687U CPU @ 2.10GHz × 4`

```
BenchmarkECP256Generate     5000        765631 ns/op
BenchmarkECP384Generate      200      10228670 ns/op
BenchmarkECP521Generate      100      17862164 ns/op
BenchmarkRSA2048Generate           2     911764954 ns/op
BenchmarkRSA3072Generate           1    1426658951 ns/op
BenchmarkRSA4096Generate           1    19010220221 ns/op
BenchmarkECP256Fingerprint    500000          3202 ns/op
BenchmarkECP384Fingerprint    500000          3304 ns/op
BenchmarkECP521Fingerprint    500000          4004 ns/op
BenchmarkRSA2048Fingerprint       10     174062887 ns/op
BenchmarkRSA3072Fingerprint        1    6930198558 ns/op
BenchmarkRSA4096Fingerprint        1    3772528822 ns/op
```
