### PR TITLE
Fix typo in comment

### DIFF
--- a/util.go
+++ b/util.go
@@ -152,7 +152,7 @@ func NewIdentityAuthTLSClientConfig(dockerUrl string, trustUnknownHosts bool, ro
 }
 
 // joseBase64UrlEncode encodes the given data using the standard base64 url
-// encoding format but with all trailing '=' characters ommitted in accordance
+// encoding format but with all trailing '=' characters omitted in accordance
 // with the jose specification.
 // http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-31#section-2
 func joseBase64UrlEncode(b []byte) string {


### PR DESCRIPTION
It was found and fixed by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>